### PR TITLE
Add a "configpath" config option

### DIFF
--- a/ebusd/config.yaml
+++ b/ebusd/config.yaml
@@ -25,6 +25,7 @@ schema:
   latency: "int(0,10000)?"
   readonly: "bool?"
   foreground: "bool?"
+  configpath: "str?"
   scanconfig: "bool?"
   logareas: "list(main|network|bus|update|all)?"
   loglevel: "list(error|notice|info|debug)?"
@@ -35,3 +36,5 @@ schema:
   mqttjson: "bool?"
   mqttlog: "bool?"
   mqttretain: "bool?"
+map: 
+  - config

--- a/ebusd/run.sh
+++ b/ebusd/run.sh
@@ -12,7 +12,7 @@ do
 done
 
 #other options
-declare options=( "device" "port" "latency" "logareas" "loglevel" "mqtthost" "mqttport" "mqttuser" "mqttpass")
+declare options=( "configpath" "device" "port" "latency" "logareas" "loglevel" "mqtthost" "mqttport" "mqttuser" "mqttpass")
 for optName in "${options[@]}"
 do
     if ! bashio::config.is_empty ${optName}; then

--- a/ebusd/translations/en.yaml
+++ b/ebusd/translations/en.yaml
@@ -14,6 +14,9 @@ configuration:
   foreground:
     name: foreground
     description: show output in supervisor log (required to keep running ebusd)
+  configpath:
+    name: Config Path
+    description: Read CSV config files from custom path. You can create a local copy of https://github.com/john30/ebusd-configuration in your "/config" folder and change configpath to e.g. "/config/ebusd-configuration/latest/en" [http://ebusd.eu/config/]
   scanconfig:
     name: Scan Config
     description: Pick CSV config files matching initial scan (ADDR="none" or empty for no initial scan message "full" for full scan, or a single hex address to scan, default is to send a broadcast ident message).


### PR DESCRIPTION
This change allows user to specify a path to a custom ebusd configuration. It is a common practice to adjust the ebusd configuration. With this change it is possible to checkout ebusd-configuration into HA /config folder and make local changes there.