### PR TITLE
Remove foreground option

### DIFF
--- a/ebusd/CHANGELOG.md
+++ b/ebusd/CHANGELOG.md
@@ -1,5 +1,9 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 0.84
+
+- BREAKING: Remove foreground option
+
 ## 0.83
 
 - BREAKING: Remove old style loglevel and logareas option

--- a/ebusd/config.yaml
+++ b/ebusd/config.yaml
@@ -29,13 +29,11 @@ ports_description:
   8889/tcp: HTTP client port (HTTP must be activated in config)
 options:
   scanconfig: true
-  foreground: true
   loglevel_all: "notice"
 schema:
   device: "device(subsystem=tty)"
   latency: "int(0,10000)?"
   readonly: "bool?"
-  foreground: "bool?"
   configpath: "str?"
   scanconfig: "bool?"
   mqtthost: "str?"

--- a/ebusd/run.sh
+++ b/ebusd/run.sh
@@ -2,8 +2,10 @@
 
 declare -a ebusd_args
 
+ebusd_args+=("--foreground")
+
 #boolean options
-declare options=( "readonly" "scanconfig" "foreground" "mqttjson" "mqttlog" "mqttretain")
+declare options=( "readonly" "scanconfig" "mqttjson" "mqttlog" "mqttretain")
 for optName in "${options[@]}"
 do
     if bashio::config.true ${optName}; then
@@ -47,11 +49,6 @@ fi
 #activate http
 if ! bashio::config.is_empty http; then
     ebusd_args+=" --httpport=8889"
-fi
-
-
-if bashio::config.false "foreground" || bashio::config.is_empty "foreground"; then
-    bashio::config.suggest.true "foreground" "ebusd add-on will stop if ebusd is not running in the foreground."
 fi
 
 echo "> ebusd ${ebusd_args[*]}"

--- a/ebusd/translations/en.yaml
+++ b/ebusd/translations/en.yaml
@@ -8,9 +8,6 @@ configuration:
   readonly:
     name: Read Only
     description: Only read from device, never write to it
-  foreground:
-    name: foreground
-    description: show output in supervisor log (required to keep running ebusd)
   configpath:
     name: Config Path
     description: Read CSV config files from custom path. You can create a local copy of https://github.com/john30/ebusd-configuration in your "/config" folder and change configpath to e.g. "/config/ebusd-configuration/latest/en" [http://ebusd.eu/config/]


### PR DESCRIPTION
eBUSd should always be run in the foreground.  Remove option and default to foreground.