### PR TITLE
WIP - Network adapter support

### DIFF
--- a/ebusd/CHANGELOG.md
+++ b/ebusd/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.84
 
-- IMPROVE: Improve configuration of wireless adapters.  Check release notes as config has changed.
+- IMPROVE: Improve configuration of network eBUSd adapters.  Check release notes as config has changed.
 - BREAKING: Config option name has changed.  custom_device changed to wireless_device
 
 ## 0.83

--- a/ebusd/CHANGELOG.md
+++ b/ebusd/CHANGELOG.md
@@ -1,5 +1,10 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 0.84
+
+- IMPROVE: Improve configuration of wireless adapters.  Check release notes as config has changed.
+- BREAKING: Config option name has changed.  custom_device changed to wireless_device
+
 ## 0.83
 
 - BREAKING: Remove old style loglevel and logareas option

--- a/ebusd/config.yaml
+++ b/ebusd/config.yaml
@@ -1,5 +1,5 @@
 name: eBUSd
-version: "0.83"
+version: "0.83.6"
 slug: ebusd
 description: >
   This Add-on runs eBUSd, a daemon for handling communication with eBUS devices
@@ -32,7 +32,7 @@ options:
   foreground: true
   loglevel_all: "notice"
 schema:
-  device: "device(subsystem=tty)"
+  device: "device(subsystem=tty)?"
   latency: "int(0,10000)?"
   readonly: "bool?"
   foreground: "bool?"
@@ -53,4 +53,4 @@ schema:
   loglevel_bus: "list(error|notice|info|debug)?"
   loglevel_update: "list(error|notice|info|debug)?"
   loglevel_main: "list(error|notice|info|debug)?"
-  custom_device: "str?"
+  wireless_device: "str?"

--- a/ebusd/config.yaml
+++ b/ebusd/config.yaml
@@ -53,4 +53,4 @@ schema:
   loglevel_bus: "list(error|notice|info|debug)?"
   loglevel_update: "list(error|notice|info|debug)?"
   loglevel_main: "list(error|notice|info|debug)?"
-  wireless_device: "str?"
+  network_device: "str?"

--- a/ebusd/run.sh
+++ b/ebusd/run.sh
@@ -22,12 +22,19 @@ do
 done
 
 #device
-if ! bashio::config.is_empty custom_device; then
-    ebusd_args+=("--device=$(bashio::config custom_device)")
-else
+if bashio::config.has_value "device" && bashio::config.has_value "wireless_device"; then
+    bashio::log.warning "USB and wireless device defined.  Only one device can be used at a time."
+    bashio::log.warning "Ignoring USB device..."
+    ebusd_args+=("--device=$(bashio::config wireless_device)")
+elif bashio::config.has_value "device"; then
     ebusd_args+=("--device=$(bashio::config device)")
+elif bashio::config.has_value "wireless_device"; then
+    ebusd_args+=("--device=$(bashio::config wireless_device)")
+else
+    bashio::log.fatal "No wireless or USB device defined. Configure a device and restart addon"
+    # stop addon, ebusd will not run without defining a device
+    bashio::addon.stop
 fi
-
 
 #logging
 declare options=( "loglevel_all" "loglevel_main" "loglevel_bus" "loglevel_update" "loglevel_network")

--- a/ebusd/run.sh
+++ b/ebusd/run.sh
@@ -22,16 +22,16 @@ do
 done
 
 #device
-if bashio::config.has_value "device" && bashio::config.has_value "wireless_device"; then
-    bashio::log.warning "USB and wireless device defined.  Only one device can be used at a time."
+if bashio::config.has_value "device" && bashio::config.has_value "network_device"; then
+    bashio::log.warning "USB and network device defined.  Only one device can be used at a time."
     bashio::log.warning "Ignoring USB device..."
-    ebusd_args+=("--device=$(bashio::config wireless_device)")
+    ebusd_args+=("--device=$(bashio::config network_device)")
 elif bashio::config.has_value "device"; then
     ebusd_args+=("--device=$(bashio::config device)")
-elif bashio::config.has_value "wireless_device"; then
-    ebusd_args+=("--device=$(bashio::config wireless_device)")
+elif bashio::config.has_value "network_device"; then
+    ebusd_args+=("--device=$(bashio::config network_device)")
 else
-    bashio::log.fatal "No wireless or USB device defined. Configure a device and restart addon"
+    bashio::log.fatal "No network or USB device defined. Configure a device and restart addon"
     # stop addon, ebusd will not run without defining a device
     bashio::addon.stop
 fi

--- a/ebusd/translations/en.yaml
+++ b/ebusd/translations/en.yaml
@@ -1,7 +1,7 @@
 configuration:
   device:
-    name: Device
-    description: -d, --device=DEV Use DEV as eBUS device ("enh:DEVICE" or "enh:IP:PORT" for enhanced device,"DEVICE" for serial device, or "[udp:]IP:PORT" for network device) [/dev/ttyUSB0]
+    name: USB Device
+    description: Use this option for USB eBUSd adapters
   latency:
     name: Latency
     description: ebusd --latency=MSEC Transfer latency in ms [0 for USB, 10 for IP]
@@ -62,6 +62,6 @@ configuration:
   loglevel_main:
     name: Log level for main messages 
     description: Only write log for matching AREA(S) below or equal to LEVEL [all:notice].  This is an alternative form to using --logareas/--loglevel and allows to specify an individual level for each area by using the option multiple times. E.g. for having only bus messages in info level and all other in error level, use --log=all:error --log=bus:info
-  custom_device:
-    name: Custom device e.g. ip address of wireless adapter
-    description: Use this option if your device is not listed in the config options
+  wireless_device:
+    name: Wireless adapter address i.e enh:192.168.0.7:9999
+    description: Use this option to for wireless eBUSd adapters ("enh:IP:PORT" for enhanced device or "[udp:]IP:PORT" for network device)

--- a/ebusd/translations/en.yaml
+++ b/ebusd/translations/en.yaml
@@ -62,6 +62,6 @@ configuration:
   loglevel_main:
     name: Log level for main messages 
     description: Only write log for matching AREA(S) below or equal to LEVEL [all:notice].  This is an alternative form to using --logareas/--loglevel and allows to specify an individual level for each area by using the option multiple times. E.g. for having only bus messages in info level and all other in error level, use --log=all:error --log=bus:info
-  wireless_device:
-    name: Wireless adapter address i.e enh:192.168.0.7:9999
-    description: Use this option to for wireless eBUSd adapters ("enh:IP:PORT" for enhanced device or "[udp:]IP:PORT" for network device)
+  network_device:
+    name: Network adapter address i.e enh:192.168.0.7:9999
+    description: Use this option to for network eBUSd adapters ("enh:IP:PORT" for enhanced device or "[udp:]IP:PORT" for network device)


### PR DESCRIPTION
Add support for network eBUSd adapter

**To-do:**

- [x] Rename config option from custom_device to network_device
- [ ] Add automatic migration script so above is not breaking change (not sure if this is possible or not)
- [x] Rename device to USB device 
- [ ] Update docs
- [x] Update run.sh to check only one device has been defined
- [x] Update run.sh so addon stops if no device has been selected