### PR TITLE
Update config.yaml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-name: Lint
+name: Lint Add-on
 
 on:
   push:
@@ -11,31 +11,18 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
-  find:
-    name: Find add-ons
-    runs-on: ubuntu-latest
-    outputs:
-      addons: ${{ steps.addons.outputs.addons_list }}
-    steps:
-      - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@v3.5.0
-
-      - name: 🔍 Find add-on directories
-        id: addons
-        uses: home-assistant/actions/helpers/find-addons@master
-
   lint:
-    name: Lint add-on ${{ matrix.path }}
+    name: Lint add-on ${{ matrix.addon }}
     runs-on: ubuntu-latest
-    needs: find
     strategy:
       matrix:
-        path: ${{ fromJson(needs.find.outputs.addons) }}
+        addon: ["ebusd-edge", "ebusd"]
+
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@v3.5.0
+        uses: actions/checkout@v3.5.2
 
       - name: 🚀 Run Home Assistant Add-on Lint
-        uses: frenck/action-addon-linter@v2.11
+        uses: frenck/action-addon-linter@v2.13
         with:
-          path: "./${{ matrix.path }}"
+          path: "./${{ matrix.addon }}"

--- a/.github/workflows/tester.yaml
+++ b/.github/workflows/tester.yaml
@@ -1,7 +1,7 @@
-name: Build and Publish Add-on
+name: Build and Test Add-on
 
 on:
-  push:
+  pull_request:
     branches:
       - main
 
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        addon: ["ebusd"]
+        addon: ["ebusd-edge", "ebusd"]
         arch: ["aarch64", "amd64", "armhf", "armv7", "i386"]
 
     steps:
@@ -23,13 +23,6 @@ jobs:
         with:
           path: ./${{ matrix.addon }}
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2.1.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-
       - name: Build ${{ matrix.arch }} add-on
         if: contains(steps.info.outputs.architectures, matrix.arch)
         uses: home-assistant/builder@2023.03.0
@@ -39,3 +32,4 @@ jobs:
             --target ${{matrix.addon}} \
             --image "ha-addon-ebusd-${{ matrix.arch }}" \
             --docker-hub "ghcr.io/${{ github.repository_owner }}"
+            --test

--- a/.github/workflows/tester.yaml
+++ b/.github/workflows/tester.yaml
@@ -31,5 +31,5 @@ jobs:
             --${{ matrix.arch }} \
             --target ${{matrix.addon}} \
             --image "ha-addon-ebusd-${{ matrix.arch }}" \
-            --docker-hub "ghcr.io/${{ github.repository_owner }}"
+            --docker-hub "ghcr.io/${{ github.repository_owner }}" \
             --test

--- a/ebusd-edge/Dockerfile
+++ b/ebusd-edge/Dockerfile
@@ -27,3 +27,7 @@ LABEL Description="eBUSd edge"
 COPY run.sh /
 RUN chmod a+x /run.sh
 CMD [ "/run.sh" ]
+
+# Health check
+HEALTHCHECK --interval=5m --timeout=3s \
+  CMD curl --fail http://127.0.0.1:8888 || exit 1

--- a/ebusd-edge/build.yaml
+++ b/ebusd-edge/build.yaml
@@ -1,9 +1,9 @@
 build_from:
-  aarch64: "ghcr.io/home-assistant/aarch64-base:3.16"
-  amd64: "ghcr.io/home-assistant/amd64-base:3.16"
-  armhf: "ghcr.io/home-assistant/armhf-base:3.16"
-  armv7: "ghcr.io/home-assistant/armv7-base:3.16"
-  i386: "ghcr.io/home-assistant/i386-base:3.16"
+  aarch64: "ghcr.io/home-assistant/aarch64-base:3.18"
+  amd64: "ghcr.io/home-assistant/amd64-base:3.18"
+  armhf: "ghcr.io/home-assistant/armhf-base:3.18"
+  armv7: "ghcr.io/home-assistant/armv7-base:3.18"
+  i386: "ghcr.io/home-assistant/i386-base:3.18"
 labels:
   org.opencontainers.image.title: "Home Assistant Add-on: Ebusd"
   org.opencontainers.image.description: "This Add-on runs eBUSd, a daemon for handling communication with eBUS devices"

--- a/ebusd-edge/config.yaml
+++ b/ebusd-edge/config.yaml
@@ -1,5 +1,5 @@
 name: eBUSd Edge
-version: "23.1"
+version: "23.1.1"
 slug: ebusd_edge
 description: >
   This Add-on runs eBUSd, a daemon for handling communication with eBUS devices
@@ -13,10 +13,9 @@ arch:
   - amd64
   - i386
 init: false
-startup: "system"
+startup: services
 services:
  - mqtt:need
-boot: "auto"
 watchdog: tcp://[HOST]:8888
 uart: true
 map:

--- a/ebusd-edge/config.yaml
+++ b/ebusd-edge/config.yaml
@@ -16,7 +16,6 @@ init: false
 startup: services
 services:
  - mqtt:need
-watchdog: tcp://[HOST]:8888
 uart: true
 map:
  - config:rw

--- a/ebusd/Dockerfile
+++ b/ebusd/Dockerfile
@@ -1,6 +1,5 @@
 ARG BUILD_FROM
 FROM $BUILD_FROM
-LABEL org.opencontainers.image.source https://github.com/lukasgrebe/ha-addons
 
 ENV LANG C.UTF-8
 

--- a/ebusd/Dockerfile
+++ b/ebusd/Dockerfile
@@ -15,3 +15,7 @@ LABEL Description="ebusd"
 COPY run.sh /
 RUN chmod a+x /run.sh
 CMD [ "/run.sh" ]
+
+# Health check
+HEALTHCHECK --interval=5m --timeout=3s \
+  CMD curl --fail http://127.0.0.1:8888 || exit 1

--- a/ebusd/build.yaml
+++ b/ebusd/build.yaml
@@ -1,9 +1,9 @@
 build_from:
-  aarch64: "ghcr.io/home-assistant/aarch64-base:3.16"
-  amd64: "ghcr.io/home-assistant/amd64-base:3.16"
-  armhf: "ghcr.io/home-assistant/armhf-base:3.16"
-  armv7: "ghcr.io/home-assistant/armv7-base:3.16"
-  i386: "ghcr.io/home-assistant/i386-base:3.16"
+  aarch64: "ghcr.io/home-assistant/aarch64-base:3.18"
+  amd64: "ghcr.io/home-assistant/amd64-base:3.18"
+  armhf: "ghcr.io/home-assistant/armhf-base:3.18"
+  armv7: "ghcr.io/home-assistant/armv7-base:3.18"
+  i386: "ghcr.io/home-assistant/i386-base:3.18"
 labels:
   org.opencontainers.image.title: "Home Assistant Add-on: Ebusd"
   org.opencontainers.image.description: "This Add-on runs eBUSd, a daemon for handling communication with eBUS devices"

--- a/ebusd/config.yaml
+++ b/ebusd/config.yaml
@@ -1,5 +1,5 @@
 name: eBUSd
-version: "23.2.0"
+version: "23.2.1"
 slug: ebusd
 description: >
   This Add-on runs eBUSd, a daemon for handling communication with eBUS devices
@@ -14,7 +14,7 @@ arch:
   - i386
 image: "ghcr.io/lukasgrebe/ha-addon-ebusd-{arch}"
 init: false
-startup: "system"
+startup: services
 services:
  - mqtt:need
 watchdog: tcp://[HOST]:8888

--- a/ebusd/config.yaml
+++ b/ebusd/config.yaml
@@ -17,7 +17,6 @@ init: false
 startup: services
 services:
  - mqtt:need
-watchdog: tcp://[HOST]:8888
 uart: true
 map:
  - config:rw


### PR DESCRIPTION
I noticed on a host reboot that the ebusd add-on fails to start.
I this PR I changed the startup config from system to services.
This should fix the race condition when the MQTT server did not start yet.

Also added:
- dependabot updates for github actions
- updated action versions
- fixed the addon linting issues:
  - removed default boot config
  - switched from watchdog config to docker healthcheck
- bumped addon base image to alpine 3.18
- added a workflow that tests if PRs build (no push)