### PR TITLE
Try to fix build and bump versions

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build ${{ matrix.arch }} add-on
         if: contains(steps.info.outputs.architectures, matrix.arch)

--- a/ebusd/Dockerfile
+++ b/ebusd/Dockerfile
@@ -8,7 +8,7 @@ RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/community" \
 RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/main" \
     >> /etc/apk/repositories
 
-RUN apk -U add --no-cache ebusd
+RUN apk add --no-cache ebusd=23.2-r0
 
 LABEL Description="ebusd"
 

--- a/ebusd/config.yaml
+++ b/ebusd/config.yaml
@@ -1,5 +1,5 @@
 name: eBUSd
-version: "23.2.1"
+version: "23.2.2"
 slug: ebusd
 description: >
   This Add-on runs eBUSd, a daemon for handling communication with eBUS devices


### PR DESCRIPTION
Current build actions fail on:
`Error response from daemon: Get "https://ghcr.io/v2/": denied: denied`
According to documentation here: https://github.com/marketplace/actions/docker-login#github-container-registry
I think this should fix it?

Also bumped the add-on version to 23.2.2 and the ebusd package to 23.2-r0.