### PR TITLE
Rename repo

### DIFF
--- a/repository.yaml
+++ b/repository.yaml
@@ -1,3 +1,3 @@
-name: Home Assistant Addons
+name: eBUSd
 url: https://github.com/LukasGrebe/ha-addons/
-maintainer: tim-devel
+maintainer: LukasGrebe

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,3 +1,3 @@
-name: eBUSd
+name: eBUSd Add-On
 url: https://github.com/LukasGrebe/ha-addons/
 maintainer: LukasGrebe


### PR DESCRIPTION
Use a more identifiable name.
Update the maintainer name.

Fixes #86 