### PR TITLE
Allow Logging to file; fixes #102

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Build ${{ matrix.arch }} add-on
         if: contains(steps.info.outputs.architectures, matrix.arch)
-        uses: home-assistant/builder@2023.12.0
+        uses: home-assistant/builder@2024.03.5
         with:
           args: |
             --${{ matrix.arch }} \

--- a/.github/workflows/tester.yaml
+++ b/.github/workflows/tester.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build ${{ matrix.arch }} add-on
         if: contains(steps.info.outputs.architectures, matrix.arch)
-        uses: home-assistant/builder@2023.12.0
+        uses: home-assistant/builder@2024.03.5
         with:
           args: |
             --${{ matrix.arch }} \

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Created by @LukasGrebe.  Improved and maintained by @tim-devel
 3. Add `https://github.com/LukasGrebe/ha-addons/`
 4. Wait for the ebusd Add-on to show up or click reload in the same overflow menu
 5. Install eBUSd.
-6. 6. Follow Documentation, Setup and Install of the Add-on
+6. Follow Documentation, Setup and Install of the Add-on
 
 
 ## [ebusd](https://github.com/LukasGrebe/ha-addons/tree/main/ebusd) 

--- a/ebusd/CHANGELOG.md
+++ b/ebusd/CHANGELOG.md
@@ -1,4 +1,8 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
+## version: 23.2.4
+
+- added the option to store rotated logs in /config through s6-log
+
 ## version: 23.2.3
 
 - fix Healthcheck. This should solve [#61](https://github.com/LukasGrebe/ha-addons/issues/61) thanks @cociweb

--- a/ebusd/config.yaml
+++ b/ebusd/config.yaml
@@ -1,5 +1,5 @@
 name: eBUSd
-version: "23.2.3"
+version: "23.2.4"
 slug: ebusd
 description: >
   This Add-on runs eBUSd, a daemon for handling communication with eBUS devices
@@ -16,10 +16,10 @@ image: "ghcr.io/lukasgrebe/ha-addon-ebusd-{arch}"
 init: false
 startup: services
 services:
- - mqtt:need
+  - mqtt:need
 uart: true
 map:
- - config:rw
+  - config:rw
 ports:
   8888/tcp: null
   8889/tcp: null
@@ -33,7 +33,7 @@ options:
   mqttint: "/etc/ebusd/mqtt-hassio.cfg"
   mqttjson: true
 schema:
-  mode: "list(enh|ens|udp)?"
+  mode: "list(enh|ens|udp)"
   device: "device(subsystem=tty)?"
   network_device: "str?"
   latency: "int(0,10000)?"
@@ -44,13 +44,16 @@ schema:
   configpath: "str?"
   commandline_options: "str?"
   accesslevel: "str?"
+  logdir_name: "str?"
+  logdir_files_number: "int?"
+  logdir_files_size: "int?"
   loglevel_all: "list(error|notice|info|debug)?"
   loglevel_network: "list(error|notice|info|debug)?"
   loglevel_bus: "list(error|notice|info|debug)?"
   loglevel_update: "list(error|notice|info|debug)?"
   loglevel_main: "list(error|notice|info|debug)?"
   loglevel_other: "list(error|notice|info|debug)?"
-  mqtthost: "str?" 
+  mqtthost: "str?"
   mqttport: "int?"
   mqttuser: "str?"
   mqttpass: "str?"

--- a/ebusd/run.sh
+++ b/ebusd/run.sh
@@ -92,6 +92,23 @@ if bashio::config.true http; then
     ebusd_args+=" --httpport=8889"
 fi
 
-echo "> ebusd ${ebusd_args[*]}"
+#Check for s6-log options
+if bashio::config.has_value logdir_name; then
+    if bashio::config.has_value logdir_files_number; then
+        logdir_files_number="n$(bashio::config logdir_files_number)"
+    else
+        logdir_files_number="n5"
+    fi
 
-ebusd ${ebusd_args[*]}
+    if bashio::config.has_value logdir_files_size; then
+        logdir_files_size=("s$(bashio::config logdir_files_size)")
+    else
+        logdir_files_size="s1000000"
+    fi
+
+    echo "> ebusd ${ebusd_args[*]} | s6-log 1 ${logdir_files_number} ${logdir_files_size} $(bashio::config logdir_name)"
+    ebusd ${ebusd_args[*]} | s6-log 1 ${logdir_files_number} ${logdir_files_size} $(bashio::config logdir_name)
+else
+    echo "> ebusd ${ebusd_args[*]}"
+    ebusd ${ebusd_args[*]}
+fi

--- a/ebusd/translations/cz.yaml
+++ b/ebusd/translations/cz.yaml
@@ -32,6 +32,15 @@ configuration:
   accesslevel:
     name: Úroveň přístupu
     description: Nastavte výchozí úroveň pro přístup (např. "*" pro všechny)
+  logdir_name:
+    name: Složka logování
+    description: Složka, kam se budou ukádat logy skrze s6-log (např. /config/ebusd-logs)
+  logdir_files_number:
+    name: Maximální počet souborů ve složce logování
+    description: Výchozí:5
+  logdir_files_size:
+    name: Maximální velikost souboru ve složce logování
+    description: Pro jednotlivý soubor, v bytech. Výchozí:1000000
   loglevel_all:
     name: "Úroveň logování pro všechny zprávy (výchozí: oznámení (notice))"
     description: Nastavte úroveň logování pro všechny zprávy.
@@ -48,7 +57,7 @@ configuration:
     name: Úroveň logování pro hlavní (main) zprávy.
     description: Nastavte úroveň logování pro hlavní (main) zprávy.
   loglevel_other:
-    name: Úroveň logování pro ostatní zprávy (včetně MQTT) 
+    name: Úroveň logování pro ostatní zprávy (včetně MQTT)
     description: Nastavte úroveň logování pro ostatní zprávy (včetně MQTT).
   network_device:
     name: Adresa síťového adaptéru například enh:192.168.0.7:9999
@@ -61,7 +70,7 @@ configuration:
     description: Přepíše automaticky nastavený MQTT port, použijte 0 pro vypnutí
   mqttuser:
     name: "Uživatelské jméno pro MQTT (výchozí: prázdné pro automtické nastavení)"
-    description:  Přepíše automaticky nastavené uživatelské jméno pro MQTT
+    description: Přepíše automaticky nastavené uživatelské jméno pro MQTT
   mqttpass:
     name: "Heslo pro MQTT (výchozí: prázdné pro automtické nastavení)"
     description: řepíše automaticky nastavené uživatelské heslo pro MQTT

--- a/ebusd/translations/en.yaml
+++ b/ebusd/translations/en.yaml
@@ -32,23 +32,32 @@ configuration:
   accesslevel:
     name: Access Level
     description: Set default access level(s) to (e.g. "*" for everything)
+  logdir_name:
+    name: Log Rotate Directory
+    description: Directory where log output will be stored via s6-log (e.g. /config/ebusd-logs)
+  logdir_files_number:
+    name: Log Rotate Max Files
+    description: Maximum number of rotated log files in Log Rotate Directory. Default:5
+  logdir_files_size:
+    name: Log Rotate Max File Size
+    description: Maximum size of rotated log file in Log Rotate Directory. Per File, in bytes. Default:1000000
   loglevel_all:
     name: "Log level for all messages (default: notice)"
     description: Set log level for all messages.
   loglevel_network:
-    name: Log level for network messages 
+    name: Log level for network messages
     description: Set log level for all messages.
   loglevel_update:
-    name: Log level for update messages 
+    name: Log level for update messages
     description: Set log level for update messages.
   loglevel_bus:
-    name: Log level for bus messages 
+    name: Log level for bus messages
     description: Set log level for bus messages.
   loglevel_main:
-    name: Log level for main messages 
+    name: Log level for main messages
     description: Set log level for main messages
   loglevel_other:
-    name: Log level for other messages (incl MQTT) 
+    name: Log level for other messages (incl MQTT)
     description: Set log level for other messages
   network_device:
     name: Network adapter address i.e enh:192.168.0.7:9999


### PR DESCRIPTION
Since ebusd is running in foregraound, the[ `--logfile` option does not work](https://github.com/john30/ebusd/discussions/595). There is however a fairly easy workaround of redirecting the output to s6-log that can maintain the output to stdout as well as sending it to a defined folder. The default setting of s6-log is up to 5files, 1MB each. This can be changed through the configuration.

This option is especially useful for debugging.

See the option:
<img width="379" alt="image" src="https://github.com/LukasGrebe/ha-addons/assets/5851137/9847c597-31ed-476d-92a4-999bf7643d2c">


And the result:
<img width="1003" alt="Snímek obrazovky 2024-03-01 194911" src="https://github.com/LukasGrebe/ha-addons/assets/5851137/31f0e8b4-2672-4c6d-8774-da355d5e9b68">
