### PR TITLE
Revert required mode

### DIFF
--- a/ebusd/config.yaml
+++ b/ebusd/config.yaml
@@ -1,5 +1,5 @@
 name: eBUSd
-version: "23.2.4"
+version: "23.2.5"
 slug: ebusd
 description: >
   This Add-on runs eBUSd, a daemon for handling communication with eBUS devices

--- a/ebusd/config.yaml
+++ b/ebusd/config.yaml
@@ -33,7 +33,7 @@ options:
   mqttint: "/etc/ebusd/mqtt-hassio.cfg"
   mqttjson: true
 schema:
-  mode: "list(enh|ens|udp)"
+  mode: "list(enh|ens|udp)?"
   device: "device(subsystem=tty)?"
   network_device: "str?"
   latency: "int(0,10000)?"


### PR DESCRIPTION
It used to be optional but was changed here: https://github.com/LukasGrebe/ha-addons/pull/108
Closes #114 