### PR TITLE
Update HEALTHCHECK in Dockerfile to not use DNS

### DIFF
--- a/ebusd/Dockerfile
+++ b/ebusd/Dockerfile
@@ -18,4 +18,4 @@ CMD [ "/run.sh" ]
 
 # Health check
 HEALTHCHECK --interval=5m --timeout=3s --start-period=90s \
-   CMD nc -z localhost 8888 || exit 1
+   CMD nc -z 127.0.0.1 8888 || exit 1


### PR DESCRIPTION
DNS resolution doesn't seem to be guaranteed in container so using 127.0.0.1 is better than using localhost