### PR TITLE
Automatic changelog and version creation by triggering a new github release

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -1,10 +1,6 @@
 name: Build and Publish Add-on
 
 on:
-  push:
-    branches:
-      - main
-    tags: [ 'v*.*.*' ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -1,0 +1,75 @@
+name: Create Changelog and Release
+# Stick the format to v0.0.0 or V0.0.0 or 0.0.0
+on:
+  push:
+    tags:
+      - '[vV]*.*.*'
+      - '*.*.*'
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+
+  release-notes:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@v4.2.1
+
+      - name: Get information
+        id: info
+        uses: home-assistant/actions/helpers/info@master
+        with:
+          path: ./${{ matrix.addon }}
+
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@v4.2.1
+
+      - name: Extract release notes and version
+        id: extract
+        run: |
+          RELEASE_INFO=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest)
+          VERSION_WITH_PREFIX=$(echo $RELEASE_INFO | jq -r .tag_name)
+          VERSION=$(echo $VERSION_WITH_PREFIX | sed 's/^[vV]//')
+          NOTES=$(echo $RELEASE_INFO | jq -r .body)
+          echo "VERSION_WITH_PREFIX=$VERSION_WITH_PREFIX" >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "NOTES=$(echo \"$NOTES\" | sed ':a;N;$!ba;s/\\n/ /g')" >> $GITHUB_ENV
+
+      - name: Append release notes to changelog.md
+        run: |
+          VERSION_WITH_PREFIX=${{ env.VERSION_WITH_PREFIX }}
+          NOTES=${{ env.NOTES }}
+          sed -i "/<!-- append new version here -->/ a ## $VERSION_WITH_PREFIX\n$NOTES\n" ${{ github.workspace }}/ebusd/CHANGELOG.md
+
+
+      - name: Update version in config.yaml
+        run: |
+          VERSION=${{ env.VERSION }}
+          sed -i "s/version: .*/version: \"$VERSION\"/" ${{ github.workspace }}/ebusd/config.yaml
+          
+      - name: Configure git
+        run: |
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+
+          
+      - name: Commit and push changes
+        run: |
+          VERSION=${{ env.VERSION }}
+          git add ${{ github.workspace }}/ebusd/CHANGELOG.md ${{ github.workspace }}/ebusd/config.yaml
+          git commit -m "Release version $VERSION"
+          git push origin HEAD:main # Update 'main' to your branch name
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger the builder workflow
+        run: |
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/actions/workflows/builder.yaml/dispatches \
+            -d '{"ref":"main"}'

--- a/.github/workflows/tester.yaml
+++ b/.github/workflows/tester.yaml
@@ -24,7 +24,6 @@ jobs:
         uses: home-assistant/actions/helpers/info@master
         with:
           path: ./${{ matrix.addon }}
-          
 
       - name: Build ${{ matrix.arch }} add-on
         if: contains(steps.info.outputs.architectures, matrix.arch)

--- a/.github/workflows/tester.yaml
+++ b/.github/workflows/tester.yaml
@@ -3,8 +3,7 @@ name: Build and Test Add-on
 on:
   push:
     branches:
-      - '**'
-      - '!main'
+      - main
   pull_request:
   workflow_dispatch:
 
@@ -25,6 +24,7 @@ jobs:
         uses: home-assistant/actions/helpers/info@master
         with:
           path: ./${{ matrix.addon }}
+          
 
       - name: Build ${{ matrix.arch }} add-on
         if: contains(steps.info.outputs.architectures, matrix.arch)

--- a/ebusd/CHANGELOG.md
+++ b/ebusd/CHANGELOG.md
@@ -1,21 +1,23 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
-## version: 23.2.6
+
+<!-- append new version here -->
+## 23.2.6
 
 - Update HEALTHCHECK in Dockerfile to not use DNS [#126](https://github.com/LukasGrebe/ha-addons/issues/126) thanks @StCyr
 
-## version: 23.2.5
+## 23.2.5
 
 - Revert required mode [#116](https://github.com/LukasGrebe/ha-addons/issues/116) thanks @tjorim
 
-## version: 23.2.4
+## 23.2.4
 
 - added the option to store rotated logs in /config through s6-log [#102](https://github.com/LukasGrebe/ha-addons/issues/102) thanks @pvyleta
 
-## version: 23.2.3
+## 23.2.3
 
 - fix Healthcheck. This should solve [#61](https://github.com/LukasGrebe/ha-addons/issues/61) thanks @cociweb
 
-## version: 23.2.0
+## 23.2.0
 
 - Change build process to use pre-build containers. This should speed up the install of the addon as the addon does not need to be compiled from Supervisor before beeing run.
 - EBUSd 23.2

--- a/ebusd/CHANGELOG.md
+++ b/ebusd/CHANGELOG.md
@@ -1,6 +1,9 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
 <!-- append new version here -->
+## 4.4.4
+- **Full Changelog**: https://github.com/cociweb/ebusd-ha_addon/compare/v2.3.6...4.4.4
+
 ## 23.2.6
 
 - Update HEALTHCHECK in Dockerfile to not use DNS [#126](https://github.com/LukasGrebe/ha-addons/issues/126) thanks @StCyr

--- a/ebusd/config.yaml
+++ b/ebusd/config.yaml
@@ -1,5 +1,5 @@
 name: eBUSd
-version: "23.2.6"
+version: "4.4.4"
 slug: ebusd
 description: >
   This Add-on runs eBUSd, a daemon for handling communication with eBUS devices


### PR DESCRIPTION
This PR enables appending the changelog.md with the content (body) of a new GitHub Release. Consequently, building and publishing can be initiated by creating a new release (tagged with v0.0.0/V0.0.0/0.0.0 format) or manually through the dispatcher. Publishing will no longer be triggered by merges or pushes.

ATTENTION!
Unfortunatelly, I'm not able to make a final test on my main branch, because the coderabbit 'hops' all the commit into this PR. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new automated workflow for managing release notes and changelogs.
  
- **Bug Fixes**
	- Streamlined the trigger conditions for GitHub Actions workflows to focus on the `main` branch.
  
- **Documentation**
	- Updated the changelog format for better clarity and consistency in version headers.
  
- **Chores**
	- Removed unnecessary branch specifications from workflow configurations.
	- Updated version numbers in configuration and changelog files to reflect the latest release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->