### PR TITLE
Automatic changelog and version creation by triggering a new github release

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -1,10 +1,6 @@
 name: Build and Publish Add-on
 
 on:
-  push:
-    branches:
-      - main
-    tags: [ 'v*.*.*' ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -1,0 +1,78 @@
+name: Create Changelog and Release
+# Stick the format to v0.0.0 or V0.0.0 or 0.0.0
+on:
+  push:
+    tags:
+      - '[vV]*.*.*'
+      - '*.*.*'
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+
+  release-notes:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@v4.2.1
+
+      - name: Extract release notes and version
+        run: |
+          RELEASE_INFO=$(curl -sL -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/releases/latest")
+          if [ $? -ne 0 ]; then
+            echo "Failed to fetch release info"
+            exit 1
+          fi
+          VERSION_WITH_PREFIX=$(echo "$RELEASE_INFO" | jq -r .tag_name)
+          VERSION=$(echo "$VERSION_WITH_PREFIX" | sed 's/^[vV]//')
+          NOTES=$(echo "$RELEASE_INFO" | jq -r .body)
+          echo "VERSION_WITH_PREFIX=${VERSION_WITH_PREFIX}" >> $GITHUB_ENV
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo 'NOTES<<EOF' >> $GITHUB_ENV
+          echo "$NOTES" >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      - name: Append release notes to changelog.md
+        run: |
+          sed -i "/<!-- append new version here -->/ a ## ${{ env.VERSION_WITH_PREFIX }}\n${{ env.NOTES }}\n" \
+            "${{ github.workspace }}/ebusd/CHANGELOG.md"
+          if [ $? -ne 0 ]; then
+            echo "Failed to update CHANGELOG.md"
+            exit 1
+          fi
+
+      - name: Update version in config.yaml
+        run: |
+          sed -i "s/version: .*/version: \"${{ env.VERSION }}\"/" \
+            "${{ github.workspace }}/ebusd/config.yaml"
+          if [ $? -ne 0 ]; then
+            echo "Failed to update config.yaml"
+            exit 1
+          fi
+          
+      - name: Configure git
+        run: |
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+
+          
+      - name: Commit and push changes
+        run: |
+          VERSION=${{ env.VERSION }}
+          git add ${{ github.workspace }}/ebusd/CHANGELOG.md ${{ github.workspace }}/ebusd/config.yaml
+          git commit -m "Release version $VERSION"
+          git push origin HEAD:main # Update 'main' to your branch name
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger the builder workflow
+        run: |
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/actions/workflows/builder.yaml/dispatches \
+            -d '{"ref":"main"}'

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -11,10 +11,9 @@ permissions:
   actions: write
 
 jobs:
-
   release-notes:
     runs-on: ubuntu-latest
-
+    
     steps:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@v4.2.1
@@ -53,13 +52,12 @@ jobs:
             echo "Failed to update config.yaml"
             exit 1
           fi
-          
+
       - name: Configure git
         run: |
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
 
-          
       - name: Commit and push changes
         run: |
           VERSION=${{ env.VERSION }}

--- a/.github/workflows/tester.yaml
+++ b/.github/workflows/tester.yaml
@@ -3,8 +3,7 @@ name: Build and Test Add-on
 on:
   push:
     branches:
-      - '**'
-      - '!main'
+      - main
   pull_request:
   workflow_dispatch:
 

--- a/ebusd/CHANGELOG.md
+++ b/ebusd/CHANGELOG.md
@@ -1,21 +1,23 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
-## version: 23.2.6
+
+<!-- append new version here -->
+## 23.2.6
 
 - Update HEALTHCHECK in Dockerfile to not use DNS [#126](https://github.com/LukasGrebe/ha-addons/issues/126) thanks @StCyr
 
-## version: 23.2.5
+## 23.2.5
 
 - Revert required mode [#116](https://github.com/LukasGrebe/ha-addons/issues/116) thanks @tjorim
 
-## version: 23.2.4
+## 23.2.4
 
 - added the option to store rotated logs in /config through s6-log [#102](https://github.com/LukasGrebe/ha-addons/issues/102) thanks @pvyleta
 
-## version: 23.2.3
+## 23.2.3
 
 - fix Healthcheck. This should solve [#61](https://github.com/LukasGrebe/ha-addons/issues/61) thanks @cociweb
 
-## version: 23.2.0
+## 23.2.0
 
 - Change build process to use pre-build containers. This should speed up the install of the addon as the addon does not need to be compiled from Supervisor before beeing run.
 - EBUSd 23.2


### PR DESCRIPTION
This PR enables appending the changelog.md with the content (body) of a new GitHub Release. Consequently, building and publishing can be initiated by creating a new release (tagged with v0.0.0/V0.0.0/0.0.0 format) or manually through the dispatcher. Publishing will no longer be triggered by merges or pushes.

ATTENTION!
Unfortunatelly, I'm not able to make a final test on my main branch, because the coderabbit 'hops' all the commit into this PR.