### PR TITLE
Bump eBUSd version to 24.1.0

### DIFF
--- a/ebusd/CHANGELOG.md
+++ b/ebusd/CHANGELOG.md
@@ -1,4 +1,8 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
+## version: 24.1.0
+
+- EBUSd 24.1
+
 ## version: 23.2.6
 
 - Update HEALTHCHECK in Dockerfile to not use DNS [#126](https://github.com/LukasGrebe/ha-addons/issues/126) thanks @StCyr

--- a/ebusd/config.yaml
+++ b/ebusd/config.yaml
@@ -1,5 +1,5 @@
 name: eBUSd
-version: "23.2.6"
+version: "24.1.0"
 slug: ebusd
 description: >
   This Add-on runs eBUSd, a daemon for handling communication with eBUS devices


### PR DESCRIPTION
The eBUSd docker image was [recently updated to 24.1](https://github.com/LukasGrebe/ha-addons/pull/152), but it's not possible to update in Home Assistant, presumably because the version wasn't bumped.

Resolves #151 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated changelog to include new version entry for EBUSd 24.1.0.
- **Chores**
	- Incremented version number in the configuration file from 23.2.6 to 24.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->