### PR TITLE
Swap base image from alpine to debian

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -7,6 +7,11 @@ on:
     tags: [ 'v*.*.*' ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         addon: ["ebusd"]
-        arch: ["aarch64", "amd64", "armhf", "armv7", "i386"]
+        arch: ["aarch64", "amd64", "armv7", "i386"]
 
     steps:
       - name: ⤵️ Check out code from GitHub

--- a/.github/workflows/tester.yaml
+++ b/.github/workflows/tester.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         addon: ["ebusd"]
-        arch: ["aarch64", "amd64", "armhf", "armv7", "i386"]
+        arch: ["aarch64", "amd64", "armv7", "i386"]
 
     steps:
       - name: ⤵️ Check out code from GitHub

--- a/ebusd/Dockerfile
+++ b/ebusd/Dockerfile
@@ -12,7 +12,9 @@ RUN curl -s -o /etc/apt/sources.list.d/ebusd.list \
 
 RUN apt-get update
 
-RUN apt-get install ebusd
+RUN apt-get install ebusd -y
+
+RUN apt-get autoremove -y
 
 RUN apt-get clean
 

--- a/ebusd/Dockerfile
+++ b/ebusd/Dockerfile
@@ -3,7 +3,17 @@ FROM $BUILD_FROM
 
 ENV LANG C.UTF-8
 
-RUN apk add --no-cache ebusd=24.1-r0
+RUN mkdir -p /etc/apt/keyrings && wget -q -O /etc/apt/keyrings/ebusd.gpg \
+    https://raw.githubusercontent.com/john30/ebusd-debian/master/ebusd.gpg
+
+RUN wget -O /etc/apt/sources.list.d/ebusd.list \
+    https://raw.githubusercontent.com/john30/ebusd-debian/master/ebusd-default-bookworm.list
+
+RUN apt-get update
+
+RUN apt-get install ebusd
+
+RUN apt-get clean
 
 LABEL Description="ebusd"
 

--- a/ebusd/Dockerfile
+++ b/ebusd/Dockerfile
@@ -3,10 +3,11 @@ FROM $BUILD_FROM
 
 ENV LANG C.UTF-8
 
-RUN mkdir -p /etc/apt/keyrings && wget -q -O /etc/apt/keyrings/ebusd.gpg \
+RUN mkdir -p /etc/apt/keyrings && curl -s -o /etc/apt/keyrings/ebusd.gpg \
     https://raw.githubusercontent.com/john30/ebusd-debian/master/ebusd.gpg
 
-RUN wget -O /etc/apt/sources.list.d/ebusd.list \
+
+RUN curl -s -o /etc/apt/sources.list.d/ebusd.list \
     https://raw.githubusercontent.com/john30/ebusd-debian/master/ebusd-default-bookworm.list
 
 RUN apt-get update

--- a/ebusd/build.yaml
+++ b/ebusd/build.yaml
@@ -1,9 +1,9 @@
 build_from:
-  aarch64: "ghcr.io/home-assistant/aarch64-base:3.21"
-  amd64: "ghcr.io/home-assistant/amd64-base:3.21"
-  armhf: "ghcr.io/home-assistant/armhf-base:3.21"
-  armv7: "ghcr.io/home-assistant/armv7-base:3.21"
-  i386: "ghcr.io/home-assistant/i386-base:3.21"
+  aarch64: "ghcr.io/home-assistant/aarch64-base-debian:bookworm"
+  amd64: "ghcr.io/home-assistant/amd64-base-debian:bookworm"
+  armhf: "ghcr.io/home-assistant/armhf-base-debian:bookworm"
+  armv7: "ghcr.io/home-assistant/armv7-base-debian:bookworm"
+  i386: "ghcr.io/home-assistant/i386-base-debian:bookworm"
 labels:
   org.opencontainers.image.title: "Home Assistant Add-on: Ebusd"
   org.opencontainers.image.description: "This Add-on runs eBUSd, a daemon for handling communication with eBUS devices"

--- a/ebusd/build.yaml
+++ b/ebusd/build.yaml
@@ -1,7 +1,6 @@
 build_from:
   aarch64: "ghcr.io/home-assistant/aarch64-base-debian:bookworm"
   amd64: "ghcr.io/home-assistant/amd64-base-debian:bookworm"
-  armhf: "ghcr.io/home-assistant/armhf-base-debian:bookworm"
   armv7: "ghcr.io/home-assistant/armv7-base-debian:bookworm"
   i386: "ghcr.io/home-assistant/i386-base-debian:bookworm"
 labels:

--- a/ebusd/config.yaml
+++ b/ebusd/config.yaml
@@ -1,5 +1,5 @@
 name: eBUSd
-version: "24.1.1"
+version: "24.1.2"
 slug: ebusd
 description: >
   This Add-on runs eBUSd, a daemon for handling communication with eBUS devices
@@ -7,7 +7,6 @@ description: >
   USB and network eBUSd adapters are supported.
 url: https://community.home-assistant.io/t/an-ebusd-add-on/344852
 arch:
-  - armhf
   - armv7
   - aarch64
   - amd64
@@ -20,6 +19,7 @@ services:
 uart: true
 map:
   - config:rw
+  - ssl:rw
 ports:
   8888/tcp: null
   8889/tcp: null


### PR DESCRIPTION
I've made some progress in connection with #147.

As a side-effect, the armhf will be dropped. see: https://github.com/LukasGrebe/ha-addons/issues/147#issuecomment-2613658564

You can test my package:

```
# remove your current (stable) image
docker rmi ghcr.io/lukasgrebe/ha-addon-ebusd-amd64:24.1.1
# pull the new one
docker pull ghcr.io/cociweb/ha-addon-ebusd-amd64:latest
# tag it as 24.1.1:
docker tag ghcr.io/cociweb/ha-addon-ebusd-amd64:latest ghcr.io/lukasgrebe/ha-addon-ebusd-amd64:24.1.1
```