### PR TITLE
Release 25.1.0

### DIFF
--- a/ebusd/CHANGELOG.md
+++ b/ebusd/CHANGELOG.md
@@ -4,7 +4,7 @@
 ## 25.1
 ### Home Assistant Add-on
 * Bump EBUSd to 25.1
-### [ebusd](https://github.com/john30/ebusd/blob/master/ChangeLog.md)
+### [ebusd](https://github.com/john30/ebusd/blob/master/ChangeLog.md) (2025-04-14)
 
 
 ## Next Release (tbd)
@@ -41,8 +41,8 @@
 #### Bug Fixes
 * Bump Home Assistant base image version from 2.18 to 3.21
 
-## 24.1 (2024-10-27)
-### [ebusd](https://github.com/john30/ebusd/blob/master/ChangeLog.md)
+## 24.1
+### [ebusd](https://github.com/john30/ebusd/blob/master/ChangeLog.md) (2024-10-27)
 #### Bug Fixes
 * fix conditional messages not being sent to message definition in MQTT integration and not being used in KNX group association
 * fix CSV dump of config files on command line

--- a/ebusd/CHANGELOG.md
+++ b/ebusd/CHANGELOG.md
@@ -1,17 +1,49 @@
 # Changelog
 
-# 24.1.1
-## Home Assistant Add-on
+# Current Release:
+## 25.1
+### Home Assistant Add-on
+* Bump EBUSd to 25.1
+### [ebusd](https://github.com/john30/ebusd/blob/master/ChangeLog.md)
 
-### Improvements
+
+## Next Release (tbd)
+### Home Assistant Add-on
+
+#### Features
+* Add Home Assistant Ingress (Web UI) [#147](https://github.com/LukasGrebe/ha-addons/issues/147)
+* Colorize Logo to identify Add-on as running in Home Assistant [#81](https://github.com/LukasGrebe/ha-addons/issues/81)
+* Easier custom MQTT device configuration [#162](https://github.com/LukasGrebe/ha-addons/issues/162)
+* Include configuration files with Add-on Backups by following [HA Changes](https://developers.home-assistant.io/blog/2023/11/06/public-addon-config/) [#160](https://github.com/LukasGrebe/ha-addons/issues/160)
+
+##### Improvements
+* Drastically reduce Settings UI [#85](https://github.com/LukasGrebe/ha-addons/issues/85)
+* Increase security classification by creating an apparmor profile [#83](https://github.com/LukasGrebe/ha-addons/issues/83)
+* Update documentation [#146](https://github.com/LukasGrebe/ha-addons/issues/146)
+
+
+#### Bug Fixes
+* fix for device string symlink with colon
+* fix "read" and "write" command response
+* fix dump of divisor
+* fix max value for S3N, S3N, SLG, and SLR types
+* fix socket options for KNXnet/IP integration
+
+
+# Older Releases
+
+## 24.1.1
+### Home Assistant Add-on
+
+#### Improvements
 * Fix semantic versioning: ebusd version is mirrored; Add-on specific iterations are denoted by the patch number. 
 
-### Bug Fixes
+#### Bug Fixes
 * Bump Home Assistant base image version from 2.18 to 3.21
 
-# 24.1 (2024-10-27)
-## [ebusd](https://github.com/john30/ebusd/blob/master/ChangeLog.md)
-### Bug Fixes
+## 24.1 (2024-10-27)
+### [ebusd](https://github.com/john30/ebusd/blob/master/ChangeLog.md)
+#### Bug Fixes
 * fix conditional messages not being sent to message definition in MQTT integration and not being used in KNX group association
 * fix CSV dump of config files on command line
 * fix DTM type with recent dates
@@ -20,7 +52,8 @@
 * fix for "reload" command not starting the scan again
 * fix datetime type mapping in MQTT
 
-### Features
+
+#### Features
 * add "inject" command
 * add config path to verbose "info" command
 * add "answer" command
@@ -32,39 +65,16 @@
 * add option to extend MQTT variables from env/cmdline
 * add date+datetime mapping, better device update check, and remove single-field-message field names in Home Assistant MQTT discovery integration
 
-### Breaking Changes
-* change default config path to https://ebus.github.io/ serving files generated from new TypeSpec message definition sources
-* change validation of identifiers to no longer accept unusual characters
-* change default device connection to be resolved automatically via mDNS
-
-
-# next (tbd)
-## Home Assistant Add-on
-
-### Features
-* Add Home Assistant Ingress (Web UI) [#147](https://github.com/LukasGrebe/ha-addons/issues/147)
-* Colorize Logo to identify Add-on as running in Home Assistant [#81](https://github.com/LukasGrebe/ha-addons/issues/81)
-* Easier custom MQTT device configuration [#162](https://github.com/LukasGrebe/ha-addons/issues/162)
-* Include configuration files with Add-on Backups by following [HA Changes](https://developers.home-assistant.io/blog/2023/11/06/public-addon-config/) [#160](https://github.com/LukasGrebe/ha-addons/issues/160)
-
-### Improvements
-* Drastically reduce Settings UI [#85](https://github.com/LukasGrebe/ha-addons/issues/85)
-* Increase security classification by creating an apparmor profile [#83](https://github.com/LukasGrebe/ha-addons/issues/83)
-* Update documentation [#146](https://github.com/LukasGrebe/ha-addons/issues/146)
-
-## [ebusd](https://github.com/john30/ebusd/blob/master/ChangeLog.md)
-### Bug Fixes
-* fix for device string symlink with colon
-* fix "read" and "write" command response
-* fix dump of divisor
-* fix max value for S3N, S3N, SLG, and SLR types
-* fix socket options for KNXnet/IP integration
-
-### Features
+#### Features:
 * add "-m" option to "encode" and "decode" commands
 * add output for commands executed with "--inject=stop"
 
-# Older Releases
+
+
+#### Breaking Changes
+* change default config path to https://ebus.github.io/ serving files generated from new TypeSpec message definition sources
+* change validation of identifiers to no longer accept unusual characters
+* change default device connection to be resolved automatically via mDNS
 
 ## 23.2.6
 

--- a/ebusd/CHANGELOG.md
+++ b/ebusd/CHANGELOG.md
@@ -1,33 +1,52 @@
 # Changelog
 
-# Current Release:
+Current Release:
+
 ## 25.1
 ### Home Assistant Add-on
+
 * Bump EBUSd to 25.1
+
 ### [ebusd](https://github.com/john30/ebusd/blob/master/ChangeLog.md) (2025-04-14)
 
+## Bug Fixes
 
-## Next Release (tbd)
+* fix for device string symlink with colon
+* fix "read" and "write" command response
+* fix dump of divisor
+* fix max value for S3N, S3N, SLG, and SLR types
+* fix socket options for KNXnet/IP integration
+* fix constant encoding in json
+* fix parsing unexpected mDNS response
+* fix longer message key and check
+* fix unnecessary poll on scan messages
+
+## Features
+
+* add "-m" option to "encode" and "decode" commands
+* add output for commands executed with "--inject=stop"
+* add secondary replacement value for date types
+* add value range and step support for numeric types
+* add numeric base types without replacement value (e.g. "U1L", "S1L", "U2L", "S2L", "U2B", "S2B", etc.)
+* add also include write messages as read-only ones in MQTT definition topic if writes are excluded
+
+
+
+# Next Release (tbd)
 ### Home Assistant Add-on
 
 #### Features
+
 * Add Home Assistant Ingress (Web UI) [#147](https://github.com/LukasGrebe/ha-addons/issues/147)
 * Colorize Logo to identify Add-on as running in Home Assistant [#81](https://github.com/LukasGrebe/ha-addons/issues/81)
 * Easier custom MQTT device configuration [#162](https://github.com/LukasGrebe/ha-addons/issues/162)
 * Include configuration files with Add-on Backups by following [HA Changes](https://developers.home-assistant.io/blog/2023/11/06/public-addon-config/) [#160](https://github.com/LukasGrebe/ha-addons/issues/160)
 
 ##### Improvements
+
 * Drastically reduce Settings UI [#85](https://github.com/LukasGrebe/ha-addons/issues/85)
 * Increase security classification by creating an apparmor profile [#83](https://github.com/LukasGrebe/ha-addons/issues/83)
 * Update documentation [#146](https://github.com/LukasGrebe/ha-addons/issues/146)
-
-
-#### Bug Fixes
-* fix for device string symlink with colon
-* fix "read" and "write" command response
-* fix dump of divisor
-* fix max value for S3N, S3N, SLG, and SLR types
-* fix socket options for KNXnet/IP integration
 
 
 # Older Releases
@@ -36,14 +55,17 @@
 ### Home Assistant Add-on
 
 #### Improvements
+
 * Fix semantic versioning: ebusd version is mirrored; Add-on specific iterations are denoted by the patch number. 
 
 #### Bug Fixes
+
 * Bump Home Assistant base image version from 2.18 to 3.21
 
 ## 24.1
 ### [ebusd](https://github.com/john30/ebusd/blob/master/ChangeLog.md) (2024-10-27)
 #### Bug Fixes
+
 * fix conditional messages not being sent to message definition in MQTT integration and not being used in KNX group association
 * fix CSV dump of config files on command line
 * fix DTM type with recent dates
@@ -54,6 +76,7 @@
 
 
 #### Features
+
 * add "inject" command
 * add config path to verbose "info" command
 * add "answer" command
@@ -65,13 +88,8 @@
 * add option to extend MQTT variables from env/cmdline
 * add date+datetime mapping, better device update check, and remove single-field-message field names in Home Assistant MQTT discovery integration
 
-#### Features:
-* add "-m" option to "encode" and "decode" commands
-* add output for commands executed with "--inject=stop"
-
-
-
 #### Breaking Changes
+
 * change default config path to https://ebus.github.io/ serving files generated from new TypeSpec message definition sources
 * change validation of identifiers to no longer accept unusual characters
 * change default device connection to be resolved automatically via mDNS

--- a/ebusd/Dockerfile
+++ b/ebusd/Dockerfile
@@ -3,6 +3,11 @@ FROM $BUILD_FROM
 
 ENV LANG C.UTF-8
 
+RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/community" \
+    >> /etc/apk/repositories
+RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/main" \
+    >> /etc/apk/repositories
+
 RUN apk add --no-cache ebusd=25.1-r0
 
 LABEL Description="ebusd"

--- a/ebusd/Dockerfile
+++ b/ebusd/Dockerfile
@@ -3,7 +3,7 @@ FROM $BUILD_FROM
 
 ENV LANG C.UTF-8
 
-RUN apk add --no-cache ebusd=24.1-r0
+RUN apk add --no-cache ebusd=25.1-r0
 
 LABEL Description="ebusd"
 

--- a/ebusd/config.yaml
+++ b/ebusd/config.yaml
@@ -1,5 +1,5 @@
 name: eBUSd
-version: "24.1.1"
+version: "25.1.0"
 slug: ebusd
 description: >
   This Add-on runs eBUSd, a daemon for handling communication with eBUS devices


### PR DESCRIPTION
Bump EBUSD to 25.1.
This PR should close #174. 

Please note, it is untested by me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated and reorganized the changelog with a new section for version 25.1, detailed upstream fixes and features, upcoming Home Assistant Add-on enhancements, and improved formatting for easier navigation.
- **Chores**
  - Upgraded the ebusd package to version 25.1 in the Docker image with additional Alpine repositories.
  - Updated configuration version to 25.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->