### PR TITLE
Allow higher latency 

### DIFF
--- a/ebusd/config.yaml
+++ b/ebusd/config.yaml
@@ -36,7 +36,7 @@ schema:
   mode: "list(enh|ens|udp)?"
   device: "device(subsystem=tty)?"
   network_device: "str?"
-  latency: "int(0,10000)?"
+  latency: "int(0,100000)?"
   pollinterval: "int(0,3600)?"
   http: "bool?"
   readonly: "bool?"


### PR DESCRIPTION
A latency of 100 000 is necessary for vaillant vr32 and is allready allowed by ebusd. It should be allowed in the configuration.
(see for example:  https://github.com/john30/ebusd/issues/1221)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the maximum allowable latency value in configuration from 10,000 to 100,000. This expands flexibility for tuning in higher-latency environments, reduces validation rejections for larger values, and supports broader deployment scenarios. Existing configurations remain compatible; no other behavior or UI is affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->