### PR TITLE
ebusd: renomme l'add-on en eBUSd_2 pour seconde instance via fork

### DIFF
--- a/ebusd/config.yaml
+++ b/ebusd/config.yaml
@@ -1,4 +1,4 @@
-name: eBUSd
+name: eBUSd_2
 version: "26.1.8"
 slug: ebusd
 description: >


### PR DESCRIPTION
Permet d'installer une seconde instance independante d'ebusd (chaudiere) en ajoutant ce fork comme depot distinct dans Home Assistant. Le hash de depot different rend l'add-on unique ; seul le libelle affiche change.


Claude-Session: https://claude.ai/code/session_01DXFYdCPSSf7SBCpVfzEbEu