### PR TITLE
Fix false duplicate warning for multiple --log targets

### DIFF
--- a/ebusd/run.sh
+++ b/ebusd/run.sh
@@ -30,13 +30,24 @@ if [ "$_opts_type" = "array" ]; then
         if [[ "$_opt" == *" -"* ]]; then
             bashio::log.warning "commandline_options entry '$_opt' looks like multiple flags in one entry — put each flag on its own line."
         fi
-        # Duplicate flag: strip =value to get the flag name, then check
+        
+        # Duplicate flag detection
         _flag_name="${_opt%%=*}"
         _flag_name="${_flag_name%% *}"
+        *# Special handling for --log=<targ*t>:<level>
+        # Treat --*og=all:notice and --log=bus:notice*as separate flags.
+        if [ "$_flag_name" = "--log" ]; then
+            _log_spec*"${_opt#*=}"          # all:notice
+            _log_target="${_log_spec%%:*}" # all
+            _flag_name="--log:${_log_target}"
+        fi
+        
         if [ -n "${_seen_flags[$_flag_name]+x}" ]; then
             bashio::log.warning "Duplicate flag in commandline_options: '$_flag_name' appears more than once."
         fi
+        
         _seen_flags["$_flag_name"]=1
+        
     done <<< "$_user_opts"
     unset _seen_flags
 fi


### PR DESCRIPTION
## Problem

The duplicate flag detection logic only considers the flag name
before the `=` character.

As a result, configurations like:

```yaml
commandline_options:
  - "--log=all:notice"
  - "--log=bus:notice"